### PR TITLE
Bump com.google.guava:guava from 32.1.3-jre to 33.2.0-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@ under the License.
     <commonsCliVersion>1.5.0</commonsCliVersion>
     <commonsIoVersion>2.11.0</commonsIoVersion>
     <guiceVersion>6.0.0</guiceVersion>
-    <guavaVersion>32.1.3-jre</guavaVersion>
+    <guavaVersion>33.2.0-jre</guavaVersion>
     <guavafailureaccessVersion>1.0.1</guavafailureaccessVersion>
     <hamcrestVersion>2.2</hamcrestVersion>
     <jakartaInjectApiVersion>2.0.1</jakartaInjectApiVersion>


### PR DESCRIPTION
pr_rerun dependabot/maven/com.google.guava-guava-33.2.0-jre to master