### PR TITLE
[MNG-8135] Profile activation based on OS properties is no longer case insensitive

### DIFF
--- a/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
+++ b/maven-model-builder/src/main/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivator.java
@@ -109,14 +109,14 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
                 reverse = true;
                 test = test.substring(1);
             }
-            result = actualVersion.equals(test);
+            result = actualVersion.equalsIgnoreCase(test);
         }
 
         return reverse != result;
     }
 
     private boolean determineArchMatch(String expectedArch, String actualArch) {
-        String test = expectedArch;
+        String test = expectedArch.toLowerCase(Locale.ENGLISH);
         boolean reverse = false;
 
         if (test.startsWith("!")) {
@@ -130,7 +130,7 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
     }
 
     private boolean determineNameMatch(String expectedName, String actualName) {
-        String test = expectedName;
+        String test = expectedName.toLowerCase(Locale.ENGLISH);
         boolean reverse = false;
 
         if (test.startsWith("!")) {
@@ -144,7 +144,7 @@ public class OperatingSystemProfileActivator implements ProfileActivator {
     }
 
     private boolean determineFamilyMatch(String family, String actualName) {
-        String test = family;
+        String test = family.toLowerCase(Locale.ENGLISH);
         boolean reverse = false;
 
         if (test.startsWith("!")) {

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
@@ -142,13 +142,13 @@ public class OperatingSystemProfileActivatorTest extends AbstractProfileActivato
         assertActivation(true, profile, newContext(null, newProperties("windows", "99", "aarch64")));
     }
 
-    @Test
     public void testCapitalOsName() {
-        Profile profile = newProfile(ActivationOS.newBuilder()
-                .family("Mac")
-                .name("Mac OS X")
-                .arch("aarch64")
-                .version("14.5"));
+        ActivationOS os = new ActivationOS();
+        os.setFamily("Mac");
+        os.setName("Mac OS X");
+        os.setArch("aarch64");
+        os.setVersion("14.5");
+        Profile profile = newProfile(os);
 
         assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
         assertActivation(false, profile, newContext(null, newProperties("windows", "1", "aarch64")));

--- a/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
+++ b/maven-model-builder/src/test/java/org/apache/maven/model/profile/activation/OperatingSystemProfileActivatorTest.java
@@ -141,4 +141,18 @@ public class OperatingSystemProfileActivatorTest extends AbstractProfileActivato
         assertActivation(false, profile, newContext(null, newProperties("windows", "99", "amd64")));
         assertActivation(true, profile, newContext(null, newProperties("windows", "99", "aarch64")));
     }
+
+    @Test
+    public void testCapitalOsName() {
+        Profile profile = newProfile(ActivationOS.newBuilder()
+                .family("Mac")
+                .name("Mac OS X")
+                .arch("aarch64")
+                .version("14.5"));
+
+        assertActivation(false, profile, newContext(null, newProperties("linux", "6.5.0-1014-aws", "amd64")));
+        assertActivation(false, profile, newContext(null, newProperties("windows", "1", "aarch64")));
+        assertActivation(false, profile, newContext(null, newProperties("windows", "99", "amd64")));
+        assertActivation(true, profile, newContext(null, newProperties("Mac OS X", "14.5", "aarch64")));
+    }
 }


### PR DESCRIPTION
pr_rerun maven-3.9.x-MNG-8135 to maven-3.9.x