### PR TITLE
[MNG-8140] Always tell why model was discarded as "invalid"

### DIFF
--- a/maven-core/src/main/java/org/apache/maven/internal/aether/LoggingRepositoryListener.java
+++ b/maven-core/src/main/java/org/apache/maven/internal/aether/LoggingRepositoryListener.java
@@ -96,12 +96,7 @@ class LoggingRepositoryListener extends AbstractRepositoryListener {
         buffer.append("The POM for ");
         buffer.append(event.getArtifact());
         buffer.append(" is invalid, transitive dependencies (if any) will not be available");
-
-        if (logger.isDebugEnabled()) {
-            logger.warn(buffer + ": " + event.getException().getMessage());
-        } else {
-            logger.warn(buffer + ", enable debug logging for more details");
-        }
+        logger.warn(buffer + ": " + event.getException().getMessage());
     }
 
     @Override


### PR DESCRIPTION
pr_rerun maven-3.9.x-MNG-8140 to maven-3.9.x